### PR TITLE
Update Wazuh and Elastic Stack versions and fix multiple bugs when installing Wazuh

### DIFF
--- a/additionalInstallationScripts/installWazuh.sh
+++ b/additionalInstallationScripts/installWazuh.sh
@@ -4,9 +4,9 @@
 #######################################
 
 # Versions to install
-ELASTIC_VERSION=6.4.1
-WAZUH_VERSION=3.6
-WAZUH_PATCH=$WAZUH_VERSION.1
+ELASTIC_VERSION=6.5.0
+WAZUH_VERSION=3.7
+WAZUH_PATCH=$WAZUH_VERSION.0
 WAZUH_PACKAGE=$WAZUH_PATCH-1
 
 # Install Wazuh server on CentOS/RHEL/Fedora.

--- a/additionalInstallationScripts/installWazuh.sh
+++ b/additionalInstallationScripts/installWazuh.sh
@@ -159,7 +159,7 @@ yum install kibana-$ELASTIC_VERSION -y -q -e 0
 ## Increase the default Node.js heap memory limit to prevent out of memory errors when installing the Wazuh App. Set the limit as follows
 export NODE_OPTIONS="--max-old-space-size=3072"
 ## Install the Wazuh App
-/usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-$(echo $WAZUH_PATCH)_$(echo $ELASTIC_VERSION).zip
+sudo -u kibana NODE_OPTIONS="--max-old-space-size=3072" /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-$(echo $WAZUH_PATCH)_$(echo $ELASTIC_VERSION).zip
 ##  Kibana will only listen on the loopback interface (localhost) by default. To set up Kibana to listen on all interfaces, edit the file /etc/kibana/kibana.yml uncommenting the setting server.host. Change the value to:
 sed -i 's/#server.host: "localhost"/server.host: "0.0.0.0"/' /etc/kibana/kibana.yml
 ## Enable and start the Kibana service

--- a/additionalInstallationScripts/installWazuhAgent.sh
+++ b/additionalInstallationScripts/installWazuhAgent.sh
@@ -29,6 +29,6 @@ done
 # set up manager ip in the ossec.conf file before restarting
 sed -i "s/MANAGER_IP/$MANAGER_IP/" /var/ossec/etc/ossec.conf
 
-systemctl restart wazuh-agent
+service wazuh-agent restart
 
 echo "Agent sucessfully registered"


### PR DESCRIPTION
*Issue #, if available:*
None 😅 

*Description of changes:*
* Update Wazuh manager (3.7.0) and Elastic Stack versions (6.5.0).
* Update command to install Wazuh Kibana app, it must now be run as `kibana` user.
* Fix bug restarting wazuh linux agent after registering it, `systemctl` is no longer available in the new Amazon Linux AMI the template uses.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
