### PR TITLE
Fix bug replacing AWS secret key in ossec.conf file

### DIFF
--- a/awsDetonationLab.template
+++ b/awsDetonationLab.template
@@ -2572,14 +2572,14 @@
                   "Ref": "wazuhUserAccessKey"
                 },
                 "/' /var/ossec/etc/ossec.conf\n",
-                "sed -i 's/insert_secret_key/",
+                "sed -i 's:insert_secret_key:",
                 {
                   "Fn::GetAtt": [
                     "wazuhUserAccessKey",
                     "SecretAccessKey"
                   ]
                 },
-                "/' /var/ossec/etc/ossec.conf\n",
+                ":' /var/ossec/etc/ossec.conf\n",
                 "/var/ossec/bin/ossec-control restart\n"
               ]
             ]


### PR DESCRIPTION
*Issue #, if available:*
#61 

*Description of changes:*
AWS secret keys can contain the `/` character. That made the sed expression to fail (the secret key doesn't always contain `/` so it wasn't always failing). I changed the sed expression in order to prevent it from failing again, now it uses `:` which I think it's not contained in AWS secret keys.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
