### PR TITLE
Retrieve latest Linux and Windows AMI IDs dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+### Fixed
+* Retrieve AMI IDs dynamically instead of having hardcoded values ([#66](https://github.com/sonofagl1tch/AWSDetonationLab/pull/66)).
+
 ## v2.0
 ### Added
 * Added `apache` user to `wheel` group in Linux vulnerable server ([#20](https://github.com/sonofagl1tch/AWSDetonationLab/pull/20)).

--- a/awsDetonationLab.template
+++ b/awsDetonationLab.template
@@ -158,19 +158,7 @@
           ]
         },
         "ImageId": {
-          "Fn::FindInMap": [
-            "AWSAMIRegionMap",
-            {
-              "Ref": "AWS::Region"
-            },
-            {
-              "Fn::FindInMap": [
-                "AMINameMap",
-                "Amazon-Linux-HVM",
-                "Code"
-              ]
-            }
-          ]
+          "Ref": "LatestLinuxAMI"
         },
         "Tags": [
           {
@@ -313,19 +301,7 @@
           ]
         },
         "ImageId": {
-          "Fn::FindInMap": [
-            "AWSAMIRegionMap",
-            {
-              "Ref": "AWS::Region"
-            },
-            {
-              "Fn::FindInMap": [
-                "AMINameMap",
-                "Windows-Server-2012",
-                "Code"
-              ]
-            }
-          ]
+          "Ref": "LatestWindows2012R2AMI"
         },
         "Tags": [
           {
@@ -504,19 +480,7 @@
           "Ref": "BastionHostProfile"
         },
         "ImageId": {
-          "Fn::FindInMap": [
-            "AWSAMIRegionMap",
-            {
-              "Ref": "AWS::Region"
-            },
-            {
-              "Fn::FindInMap": [
-                "AMINameMap",
-                "Amazon-Linux-HVM",
-                "Code"
-              ]
-            }
-          ]
+          "Ref": "LatestLinuxAMI"
         },
         "SecurityGroups": [
           {
@@ -1454,19 +1418,7 @@
           ]
         },
         "ImageId": {
-          "Fn::FindInMap": [
-            "AWSAMIRegionMap",
-            {
-              "Ref": "AWS::Region"
-            },
-            {
-              "Fn::FindInMap": [
-                "AMINameMap",
-                "Amazon-Linux-HVM",
-                "Code"
-              ]
-            }
-          ]
+          "Ref": "LatestLinuxAMI"
         },
         "Tags": [
           {
@@ -2384,19 +2336,7 @@
           ]
         },
         "ImageId": {
-          "Fn::FindInMap": [
-            "AWSAMIRegionMap",
-            {
-              "Ref": "AWS::Region"
-            },
-            {
-              "Fn::FindInMap": [
-                "AMINameMap",
-                "Amazon-Linux-HVM",
-                "Code"
-              ]
-            }
-          ]
+          "Ref": "LatestLinuxAMI"
         },
         "Tags": [
           {
@@ -2885,78 +2825,6 @@
       },
       "us-gov-west-1": {
         "AWSNATHVM": "ami-c177eba0"
-      },
-      "AMI": {
-        "AMZNLINUXHVM": "amzn-ami-hvm-2018.03.0.20181119-x86_64-gp2",
-        "WS2012R2": "Windows_Server-2012-R2_RTM-English-64Bit-Base-2018.10.14"
-      },
-      "us-east-1": {
-        "AMZNLINUXHVM": "ami-0d19227302e8e4bb5",
-        "WS2012R2": "ami-0f764b6278b21abc8"
-      },
-      "us-east-2": {
-        "AMZNLINUXHVM": "ami-0ec1948d5caef658a",
-        "WS2012R2": "ami-0baa9c4ebf8e6f9e8"
-      },
-      "us-west-1": {
-        "AMZNLINUXHVM": "ami-0c3ca2c6f4edb5546",
-        "WS2012R2": "ami-0d1b94419de19380d"
-      },
-      "us-west-2": {
-        "AMZNLINUXHVM": "ami-0b5913cdbba67598e",
-        "WS2012R2": "ami-0cd140ff42967fb4d"
-      },
-      "ca-central-1": {
-        "AMZNLINUXHVM": "ami-08f0313c2834a2ff7",
-        "WS2012R2": "ami-0bcfa0d5c475e4908"
-      },
-      "eu-central-1": {
-        "AMZNLINUXHVM": "ami-0f0debf49705e047c",
-        "WS2012R2": "ami-0f8d4eb0ac15ad667"
-      },
-      "eu-west-1": {
-        "AMZNLINUXHVM": "ami-06e710681e5ee07aa",
-        "WS2012R2": "ami-027a1145f8fb3078f"
-      },
-      "eu-west-2": {
-        "AMZNLINUXHVM": "ami-096629e5eb19568cc",
-        "WS2012R2": "ami-009168d63faed8911"
-      },
-      "eu-west-3": {
-        "AMZNLINUXHVM": "ami-044e19acaba1ddac8",
-        "WS2012R2": "ami-04f50d3c7b555d55a"
-      },
-      "ap-southeast-1": {
-        "AMZNLINUXHVM": "ami-00cbdef8d2acf44a7",
-        "WS2012R2": "ami-0fc09699e39bd476f"
-      },
-      "ap-southeast-2": {
-        "AMZNLINUXHVM": "ami-0fbfb4926256a1f1e",
-        "WS2012R2": "ami-05c0c790a9f437fb2"
-      },
-      "ap-northeast-2": {
-        "AMZNLINUXHVM": "ami-0befa04e7b1ba50f9",
-        "WS2012R2": "ami-0699e47d765f00e8b"
-      },
-      "ap-northeast-1": {
-        "AMZNLINUXHVM": "ami-016ad6443b4a3d960",
-        "WS2012R2": "ami-063fe91b4d0205dee"
-      },
-      "ap-south-1": {
-        "AMZNLINUXHVM": "ami-04611067ce944d00f",
-        "WS2012R2": "ami-06de7188f7ca5b564"
-      },
-      "sa-east-1": {
-        "AMZNLINUXHVM": "ami-088018633b4291710",
-        "WS2012R2": " ami-087469fb80c075b45"
-      }
-    },
-    "AMINameMap": {
-      "Amazon-Linux-HVM": {
-        "Code": "AMZNLINUXHVM"
-      },
-      "Windows-Server-2012": {
-        "Code": "WS2012R2"
       }
     },
     "Defaults": {
@@ -3124,6 +2992,14 @@
       "Type": "String",
       "Description": "Virus Total API key to use whith Wazuh's FIM module.",
       "Default": "None"
+    },
+    "LatestLinuxAMI": {
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+      "Default": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+    },
+    "LatestWindows2012R2AMI": {
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+      "Default": "/aws/service/ami-windows-latest/Windows_Server-2012-R2_RTM-English-64Bit-Base"
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
fixes #65
*Description of changes:*
I used [`AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html) resource to dynamically fetch AMI IDs 😄 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
