### PR TITLE
Install pip and python dependencies on installWazuh script

### DIFF
--- a/additionalInstallationScripts/installWazuh.sh
+++ b/additionalInstallationScripts/installWazuh.sh
@@ -66,13 +66,14 @@ set_global_parameters() {
 install_dependencies() {
     ## RHEL/CentOS/Fedora/Amazon/SUSE based OS
     if [ "${OS_FAMILY}" == "RHEL" ] || [ "${OS_FAMILY}" == "SUSE" ]; then
-        ${PKG_INSTALL} ${PKG_OPTIONS} openssl wget
+        ${PKG_INSTALL} ${PKG_OPTIONS} openssl wget python-pip
     ## Debian/Ubuntu based OS
     else
         ${PKG_MANAGER} update
         ${PKG_INSTALL} ${PKG_OPTIONS} curl apt-transport-https lsb-release \
-        openssl software-properties-common dirmngr
+        openssl software-properties-common dirmngr python-pip
     fi
+    pip install boto3 requests
 }
 
 add_nodejs_repository() {

--- a/awsDetonationLab.template
+++ b/awsDetonationLab.template
@@ -2249,7 +2249,6 @@
                 "wget -O /home/ec2-user/install https://raw.githubusercontent.com/sonofagl1tch/AWSDetonationLab/master/additionalInstallationScripts/installWazuh.sh\n",
                 "chmod +x /home/ec2-user/install\n",
                 "bash /home/ec2-user/install -u false\n",
-                "pip install boto3 requests\n",
                 "sed -i 's/cloudtraillogging/",
                 {
                   "Ref": "S3BucketCloudTrail"


### PR DESCRIPTION
*Issue #, if available:*
fixes #71 

*Description of changes:*
Added installation of `python-pip` to the wazuhInstall script and moved install of `boto3` and `requests` from template to installWazuh script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
