### PR TITLE
Update wazuh inspector configuration using service option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+### Changed
+* Inspector logs are fetched directly from the AWS API instead of being fetched from an S3 bucket.
+
 ## v2.1
 ### Added
 * Automate setting `wazuh-alerts-3.x-*` as Kibana's default index pattern ([#64](https://github.com/sonofagl1tch/AWSDetonationLab/pull/64/)).

--- a/additionalInstallationScripts/installWazuh.sh
+++ b/additionalInstallationScripts/installWazuh.sh
@@ -160,12 +160,10 @@ add_aws_config() {
       <access_key>insert_access_key</access_key>
       <secret_key>insert_secret_key</secret_key>
     </bucket>
-    <bucket type="custom">
-      <name>inspectorlogging</name>
-      <path>firehose</path>
-      <access_key>insert_access_key</access_key>
-      <secret_key>insert_secret_key</secret_key>
-    </bucket>
+    <service type="inspector">
+        <access_key>insert_access_key</access_key>
+        <secret_key>insert_secret_key</secret_key>
+    </service>
     <bucket type="custom">
       <name>macielogging</name>
       <path>firehose</path>

--- a/awsDetonationLab.template
+++ b/awsDetonationLab.template
@@ -733,42 +733,6 @@
         }
       }
     },
-    "FirehosedeliverystreamInspector": {
-      "DependsOn": [
-        "firehosedeliveryPolicyInspector"
-      ],
-      "Type": "AWS::KinesisFirehose::DeliveryStream",
-      "Properties": {
-        "ExtendedS3DestinationConfiguration": {
-          "BucketARN": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:s3:::",
-                {
-                  "Ref": "S3BucketInspector"
-                }
-              ]
-            ]
-          },
-          "BufferingHints": {
-            "IntervalInSeconds": "300",
-            "SizeInMBs": "5"
-          },
-          "CompressionFormat": "UNCOMPRESSED",
-          "Prefix": "firehose/",
-          "RoleARN": {
-            "Fn::GetAtt": [
-              "firehosedeliveryRoleInspector",
-              "Arn"
-            ]
-          },
-          "ProcessingConfiguration": {
-            "Enabled": "false"
-          }
-        }
-      }
-    },
     "FirehosedeliverystreamMacie": {
       "DependsOn": [
         "firehosedeliveryPolicyGuardDuty"
@@ -841,6 +805,33 @@
                 "ec2:DescribeFlowLogs"
               ],
               "Resource": "*"
+            }
+          ]
+        }
+      }
+    },
+    "IamPolicyWazuhInspectorFindings": {
+      "Type": "AWS::IAM::Policy",
+      "DependsOn": "wazuhUser",
+      "Properties": {
+        "Users": [
+          {
+            "Ref": "wazuhUser"
+          }
+        ],
+        "PolicyName": "wazuh-describe-inspector-findings",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "inspector:ListFindings",
+                "inspector:DescribeFindings"
+              ],
+              "Resource": [
+                "*"
+              ]
             }
           ]
         }
@@ -976,29 +967,6 @@
                       "arn:aws:s3:::",
                       {
                         "Ref": "S3BucketVPCflow"
-                      }
-                    ]
-                  ]
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:s3:::",
-                      {
-                        "Ref": "S3BucketInspector"
-                      },
-                      "/*"
-                    ]
-                  ]
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:s3:::",
-                      {
-                        "Ref": "S3BucketInspector"
                       }
                     ]
                   ]
@@ -1516,11 +1484,6 @@
       "Properties": {}
     },
     "S3BucketIAM": {
-      "DeletionPolicy": "Retain",
-      "Type": "AWS::S3::Bucket",
-      "Properties": {}
-    },
-    "S3BucketInspector": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::S3::Bucket",
       "Properties": {}
@@ -2115,58 +2078,6 @@
         ]
       }
     },
-    "firehosedeliveryPolicyInspector": {
-      "Type": "AWS::IAM::Policy",
-      "Properties": {
-        "PolicyName": "firehose_delivery_policy_Inspector",
-        "PolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Action": [
-                "s3:AbortMultipartUpload",
-                "s3:GetBucketLocation",
-                "s3:GetObject",
-                "s3:ListBucket",
-                "s3:ListBucketMultipartUploads",
-                "s3:PutObject"
-              ],
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:s3:::",
-                      {
-                        "Ref": "S3BucketInspector"
-                      }
-                    ]
-                  ]
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:s3:::",
-                      {
-                        "Ref": "S3BucketInspector"
-                      },
-                      "*"
-                    ]
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "Roles": [
-          {
-            "Ref": "firehosedeliveryRoleInspector"
-          }
-        ]
-      }
-    },
     "firehosedeliveryPolicyMacie": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
@@ -2262,11 +2173,6 @@
                 "sed -i 's/iamlogging/",
                 {
                   "Ref": "S3BucketIAM"
-                },
-                "/' /var/ossec/etc/ossec.conf\n",
-                "sed -i 's/inspectorlogging/",
-                {
-                  "Ref": "S3BucketInspector"
                 },
                 "/' /var/ossec/etc/ossec.conf\n",
                 "sed -i 's/macielogging/",
@@ -2492,44 +2398,6 @@
         ]
       }
     },
-    "CloudwatchEventRuleInspector": {
-      "DependsOn": [
-        "cloudwatchEventsInvokeKinesisTargetRole"
-      ],
-      "Type": "AWS::Events::Rule",
-      "Properties": {
-        "Description": "Events Rule with KinesisParameters",
-        "EventPattern": {
-          "source": [
-            "aws.inspector"
-          ]
-        },
-        "RoleArn": {
-          "Fn::GetAtt": [
-            "cloudwatchEventsInvokeKinesisTargetRole",
-            "Arn"
-          ]
-        },
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Id": "Id123",
-            "Arn": {
-              "Fn::GetAtt": [
-                "FirehosedeliverystreamInspector",
-                "Arn"
-              ]
-            },
-            "RoleArn": {
-              "Fn::GetAtt": [
-                "cloudwatchEventsInvokeKinesisTargetRole",
-                "Arn"
-              ]
-            }
-          }
-        ]
-      }
-    },
     "cloudwatchEventsInvokeKinesisTargetRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -2593,35 +2461,6 @@
               "Resource": {
                 "Fn::GetAtt": [
                   "FirehosedeliverystreamMacie",
-                  "Arn"
-                ]
-              }
-            }
-          ]
-        },
-        "Roles": [
-          {
-            "Ref": "cloudwatchEventsInvokeKinesisTargetRole"
-          }
-        ]
-      }
-    },
-    "cloudwatchEventsInvokeKinesisTargetPolicyInspector": {
-      "Type": "AWS::IAM::Policy",
-      "Properties": {
-        "PolicyName": "firehose_delivery_policy_EventsInvoke-inspector",
-        "PolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Action": [
-                "firehose:PutRecord",
-                "firehose:PutRecordBatch"
-              ],
-              "Resource": {
-                "Fn::GetAtt": [
-                  "FirehosedeliverystreamInspector",
                   "Arn"
                 ]
               }
@@ -2699,31 +2538,6 @@
       }
     },
     "firehosedeliveryRoleIAM": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "firehose.amazonaws.com"
-              },
-              "Action": "sts:AssumeRole",
-              "Condition": {
-                "StringEquals": {
-                  "sts:ExternalId": {
-                    "Ref": "AWS::AccountId"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
-    "firehosedeliveryRoleInspector": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {


### PR DESCRIPTION
*Issue #, if available:*
closes #48 

*Description of changes:*
Wazuh supports using the AWS API to fetch inspector findings directly, without storing findings in an intermediate S3 bucket. This PR adds support to use that and removes all inspector-bucket related stuff.

This is a screenshot of an inspector alert in Kibana:
![inspector_alert.png](https://user-images.githubusercontent.com/8604906/56099424-100cd200-5f0d-11e9-9149-8ded3ae2e16e.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
